### PR TITLE
Fix minor heap issues

### DIFF
--- a/libyarattd/src/libyarattd_scheduler.c
+++ b/libyarattd/src/libyarattd_scheduler.c
@@ -371,6 +371,15 @@ int scheduler_delete(YR_TTD_SCHEDULER* scheduler)
   if (scheduler->functions)
     vect_delete(scheduler->functions);
 
+  if (scheduler->virtual_alloc_map)
+  {
+    vect_delete(scheduler->virtual_alloc_map->map);
+    yr_free(scheduler->virtual_alloc_map);
+    yr_free(scheduler->nt_allocate_virtual_memory);
+  }
+
+  scheduler->engine->IReplayEngine->Destroy_Replay_Engine(scheduler->engine);
+
   yr_free(scheduler);
   return ERROR_SUCCESS;
 }

--- a/libyarattd/src/libyarattd_utils.c
+++ b/libyarattd/src/libyarattd_utils.c
@@ -54,23 +54,21 @@ GuestAddress get_qword_at_address(
     TTD_Replay_ICursor* cursor,
     GuestAddress address)
 {
-  MemoryBuffer* memory_buffer = (struct MemoryBuffer*) yr_malloc(
-      sizeof(struct MemoryBuffer));
-  TBuffer* buf = (struct TBuffer*) yr_malloc(sizeof(struct TBuffer));
-  if (buf == NULL || memory_buffer == NULL)
+  MemoryBuffer memory_buffer;
+  TBuffer buf;
+  buf.size = sizeof(void*);
+  buf.dst_buffer = yr_malloc(buf.size);
+
+  if (!buf.dst_buffer)
     return 0;
 
-  buf->size = sizeof(void*);
-  buf->dst_buffer = yr_malloc(buf->size);
-  cursor->ICursor->QueryMemoryBuffer(cursor, memory_buffer, address, buf, 0);
+  cursor->ICursor->QueryMemoryBuffer(cursor, &memory_buffer, address, &buf, 0);
 
-  if (memory_buffer->data == NULL)
+  if (memory_buffer.data == NULL)
     return 0;
 
-  GuestAddress value = *((GuestAddress*) memory_buffer->data);
-  yr_free(memory_buffer->data);
-  yr_free(memory_buffer);
-  yr_free(buf);
+  GuestAddress value = *((GuestAddress*) memory_buffer.data);
+  yr_free(memory_buffer.data);
   return value;
 }
 

--- a/yara-ttd/src/yara-ttd.c
+++ b/yara-ttd/src/yara-ttd.c
@@ -519,7 +519,7 @@ static int scan_ttd(YR_SCANNER *scanner, const wchar_t *filename)
     TRY(yr_scanner_scan_ttd(scheduler, scanner, scan_cursor));
   }
 
-  scheduler->engine->IReplayEngine->Destroy_Replay_Engine(scheduler->engine);
+  scheduler_delete(scheduler);
 
   return ERROR_SUCCESS;
 }


### PR DESCRIPTION
* Remove useless heap allocations that often leads to memory corruption when querying memory with TTD
* Destroy the scheduler